### PR TITLE
Use a TreeMap to order the keys inside the hash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.authentic</groupId>
 	<artifactId>authentic-componentless-utilities</artifactId>
-	<version>3.0.4</version>
+	<version>3.0.5</version>
 	<name>authentic componentless utilities</name>
 	<description>Extends the beanless capability with components that can handle many scenarios without writing any code, as well as providing some utilities for the frontend to use.</description>
 

--- a/src/main/java/com/authentic/components/ListContentComponent.java
+++ b/src/main/java/com/authentic/components/ListContentComponent.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import static com.authentic.util.Constants.COMPONENT_PARAMETER_MAP;
 import static com.authentic.util.Constants.REQUEST_ATTR_DOCUMENTS;
@@ -87,17 +88,21 @@ public class ListContentComponent extends BaseHstComponent {
         final HashMap<String, Object> paramMap;
         Set<Map.Entry<String, Object>> paramSet;
         try {
-            List<HippoBean> beans = new ArrayList<>();
             paramMap = (HashMap<String, Object>) request.getAttribute(COMPONENT_PARAMETER_MAP);
             paramSet = paramMap.entrySet();
+            TreeMap<String, HippoBean> keyBeanHolder = new TreeMap<>();
+
             paramSet.stream()
                     .filter(e -> e.getKey().matches("document[0-9?]")
                             && isDocumentPath(e.getValue()))
                     .forEach(e -> {
                         HippoBean bean = getBeanFromPath((String) e.getValue(), beanManager, root);
-                        if (bean != null)
-                            beans.add(bean);
+                        if (bean != null) {
+                            keyBeanHolder.put(e.getKey(), bean);
+                        }
                     });
+
+            List<HippoBean> beans = new ArrayList<>(keyBeanHolder.values());
 
             return helper.buildPageable(beans);
 


### PR DESCRIPTION
We found that the list of documents returned was unordered.

In order to maintain the order of the documents in the API ... the change in the code is using a TreeMap to sort the index